### PR TITLE
Tutorials 1, 2, 11-14

### DIFF
--- a/Tutorial Series/Introduction to Financial Python/Tutorial00 Introduction to Financial Python.html
+++ b/Tutorial Series/Introduction to Financial Python/Tutorial00 Introduction to Financial Python.html
@@ -1,7 +1,7 @@
-<h2>About</h2>
+﻿<h2>About</h2>
 <p>This tutorial series introduces basic Python applied to financial concepts. If you have great investment ideas but don't know how to write them, or if you think you need to learn some basic skills in quantitative finance, then this is a good starting point. The series is broken into four parts: python, math and statistics, basic financial concepts related to investment and financial time series analysis.</p>
 
-<p>We not only introduce the concepts but also show you how to apply the introduced techniques step by step using Python code snippets. We use real financial datasets as examples and after each chapter we design a QuantConnect algorithm applying what we learned.</p>
+<p>We not only introduce the concepts but also show you how to apply the introduced techniques step by step using Python code snippets. We use real financial datasets as examples and after each chapter we design a QuantConnect algorithm applying what we learned.</p>
 
 <div class="row tutorials-page-about">
 	<div class="col-xs-12 col-md-4">
@@ -43,9 +43,9 @@ First glimpse of Python.
 The essential of programming.
 <a><i class="fa fa-chevron-right"></i> Read Tutorial</a></td>
 </tr>
-<tr onclick="window.document.location='/tutorials/introduction-python-data-types-data-structures/';"  class="clickable" ><td>3</td>
+<tr onclick="window.document.location='/tutorials/introduction-python-functions-object-oriented-programming/';"  class="clickable" ><td>3</td>
 <td>
-<h2>Python: Functions and Objective-oriented Programming</h2>
+<h2>Python: Functions and Object-Oriented Programming</h2>
 The Python magic.
 <a><i class="fa fa-chevron-right"></i> Read Tutorial</a></td>
 </tr>
@@ -105,7 +105,7 @@ Don't put all the eggs in one basket.
 </tr>
 <tr onclick="window.document.location='/tutorials/capital-asset-pricing-model/';"  class="clickable" ><td>13</td>
 <td>
-<h2>Capital Asset Pricing Model</h2>
+<h2>Market Risk</h2>
 Beta and Alpha.
 <a><i class="fa fa-chevron-right"></i> Read Tutorial</a></td>
 </tr>

--- a/Tutorial Series/Introduction to Financial Python/Tutorial01 Data Types and Data Structures.html
+++ b/Tutorial Series/Introduction to Financial Python/Tutorial01 Data Types and Data Structures.html
@@ -1,14 +1,16 @@
-<h2>Introduction</h2>
-This tutorial provides basic introduction to Python language. If you are new to python, we suggest that you should read through this tutorial and run the code snippets so that you can go through to our following topics. If you are an advanced python user, please feel free to skip this chapter.
-<h2>Basic Variable Type</h2>
-Python variables are used to store values for programming use. The basic variable types in python we covered in this tutorial include: strings, integers, floating point numbers and booleans.
+﻿This tutorial provides a basic introduction to the Python programming language. If you are new to Python, you should run the code snippets while reading this tutorial. If you are an advanced Python user, please feel free to skip this chapter.
 
-Strings in python are identified as a contiguous set of characters represented in either single quotes (' ') or double quotes(" ").
+<h2>Basic Variable Types</h2>
+
+The basic types of variables in Python are: strings, integers, floating point numbers and booleans.
+
+Strings in python are identified as a contiguous set of characters represented in either single quotes (' ') or double quotes (" ").
 <pre class="prettyprint linenums">my_string1 = 'Welcome to'
 my_string2 = "QuantConnect"
 print my_string1 + ' ' + my_string2
 [out]: Welcome to QuantConnect
 </pre>
+
 An integer is a round number with no values after the decimal point.
 <pre class="prettyprint linenums">my_int = 10
 print my_int
@@ -16,6 +18,7 @@ print my_int
 print type(my_int)
 [out]: type 'int'
 </pre>
+
 The built-in function int() can convert a string into an integer.
 <pre class="prettyprint linenums">my_string = "100"
 print type(my_string)
@@ -24,6 +27,7 @@ my_int = int(my_string)
 print type(my_int)
 [out]: type 'int'
 </pre>
+
 A floating point number, or a float, is a real number in mathematics. In Python we need to include a value after a decimal point to define it as a float.
 <pre class="prettyprint linenums">my_float = 1.0
 print type(my_float)
@@ -32,21 +36,24 @@ my_int = 1
 print type(my_int)
 [out]: type 'int'
 </pre>
-As you can see above, if we don't include a decimal value, the variable would be defined as an integer.
-The built-in function float() can convert a string or an integer into a float.
+
+As you can see above, if we don't include a decimal value, the variable would be defined as an integer. The built-in function float() can convert a string or an integer into a float.
 <pre class="prettyprint linenums">my_string = "100"
 my_float = float(my_string)
 print type(my_float)
 [out]: type 'float'
 </pre>
-A boolean, or bool, is a binary variable. Its value can only be either True or False. It is useful when we do some logic operations, which would be covered in our next chapter.
+
+A boolean, or bool, is a binary variable. Its value can only be True or False. It is useful when we do some logic operations, which would be covered in our next chapter.
 <pre class="prettyprint linenums">my_bool = False
 print my_bool
 [out]: False
 print type(my_bool)
 [out]: type 'bool'
 </pre>
+
 <h2>Basic Math Operations</h2>
+
 The basic math operators in python are demonstrated below:
 <pre class="prettyprint linenums">
 print "Addition ", 1+1
@@ -61,109 +68,137 @@ Multiplication  6
 Division  5
 exponent 8
 </pre>
-Please note that if you use an integer to divide an integer, you would end up getting an integer.
+
+In Python 2, if you divide an integer by another integer, you will get an integer.
 <pre class="prettyprint linenums">
 print 1/3
 [out]: 0
 print 1.0/3
 [out]: 0.3333333333
 </pre>
-In order to get the float result you need, remember to define either your numerator or denominator as float type.
+
+To get a float instead of an integer, either the numerator or denominator must be a float as shown above. This isn't a problem in Python 3 since 1/3 will return 0.3333333333
+
 <h2>Data Collections</h2>
+
 <h3>List</h3>
-The list is an ordered collection of values. A list is mutable, which means you can change a list's value without changing the list itself. Creating a list is simply putting different comma-separated values between square brackets.
+
+A list is an <strong>ordered</strong> collection of values. A list is mutable, which means you can change a list's value without changing the list itself. Creating a list is simply putting different comma-separated values between square brackets.
 <pre class="prettyprint linenums">my_list = ['Quant', 'Connect', 1,2,3]
 print my_list
 [out]: ['Quant', 'Connect', 1, 2, 3]
 </pre>
-The values in a list are called "elements". We can access to list elements by indexing. Python index starts from 0. Please note that If you have a list of n length, the index of the first element will be 0, and that of the last element will be n-1. By the way, the length of a collection can be obtained by the built-in function len().
+
+The values in a list are called "elements". We can access list elements by indexing. Python index starts from 0. So if you have a list of length <em>n</em>, the index of the first element will be 0, and that of the last element will be <em>n</em> &minus; 1. By the way, the length of a list can be obtained by the built-in function len().
 <pre class="prettyprint linenums">my_list = ['Quant', 'Connect', 1,2,3]
 print len(my_list)
 [out]: 5
 print my_list[0]
 [out]: Quant
-print my_list[len(my_list) -1]
+print my_list[len(my_list) - 1]
 [out]: 3
 </pre>
+
 You can also change the elements in the list by accessing an index and assigning a new value.
 <pre class="prettyprint linenums">my_list = ['Quant','Connect',1,2,3]
 my_list[2] = 'go'
 print my_list
 [out]: ['Quant', 'Connect', 'go', 2, 3]
 </pre>
-If you wish to add or remove an element from a list, you can use the methods of the list objects: list.append() and list.remove().
-<pre class="prettyprint linenums">my_list = ['Quant']
-my_list.append('Connect')
-print my_list
-[out]: ['Quant', 'Connect']
-my_list.remove('Quant')
-print my_list
-[out]: ['Connect']
-</pre>
-A list can also be sliced by using colon(:).
+
+A list can also be sliced with a colon:
 <pre class="prettyprint linenums">my_list = ['Quant','Connect',1,2,3]
 print my_list[1:3]
 [out]: ['Connect', 1]
 </pre>
-The slice starts from the first element indicated, but excludes the last element indicated.
-We can selected all the values after a certain one:
+
+The slice starts from the first element indicated, but excludes the last element indicated. Here we select all elements starting from index 1, which refers to the second element:
 <pre class="prettyprint linenums">print my_list[1:]
 [out]: ['Connect', 1, 2, 3]
 </pre>
-And all the values before a certain one:
+
+And all elements up to but excluding index 3:
 <pre class="prettyprint linenums">print my_list[:3]
 [out]: ['Quant', 'Connect', 1]
 </pre>
+
+If you wish to add or remove an element from a list, you can use the append() and remove() methods for lists as follows:
+<pre class="prettyprint linenums">my_list = ['Hello', 'Quant']
+my_list.append('Hello')
+print my_list
+[out]: ['Hello', 'Quant', 'Hello']
+my_list.remove('Hello')
+print my_list
+[out]: ['Quant', 'Hello']
+</pre>
+
+When there are repeated instances of "Hello", the first one is removed.
+
 <h3>Tuple</h3>
+
 A tuple is a data structure type similar to a list. The difference is that a tuple is immutable, which means you can't change the elements in it once it's defined. We create a tuple by putting comma-separated values between parentheses.
 <pre class="prettyprint linenums">my_tuple = ('Welcome','to','QuantConnect')
 </pre>
+
 Just like a list, a tuple can be sliced by using index.
 <pre class="prettyprint linenums">my_tuple = ('Welcome','to','QuantConnect')
 print my_tuple[1:]
 [out]: ('to', 'QuantConnect')
 </pre>
+
 <h3>Set</h3>
-A set is an unordered collection with no duplicate elements. The built-in function set() can be used to create sets.
+
+A set is an <strong>unordered</strong> collection with <strong>no duplicate</strong> elements. The built-in function set() can be used to create sets.
 <pre class="prettyprint linenums">stock_list = ['AAPL','GOOG','IBM','AAPL','IBM','FB','F','GOOG']
 stock_set = set(stock_list)
 print stock_set
 [out]: set(['GOOG', 'FB', 'AAPL', 'IBM', 'F'])
 </pre>
-Set is an easy way to remove duplicated elements from a list.
+Set is an easy way to remove duplicate elements from a list.
+
 <h3>Dictionary</h3>
-Dictionary is one of the most important data structures in python. Unlike sequences, which are indexed by a range of numbers, dictionaries are indexed by keys, which can be either strings or numbers. A dictionary is an unordered set of keys: value pairs, with the requirement that the keys are unique. We create a dictionary by placing a comma-separated list of key:value pair within the braces.
-<pre class="prettyprint linenums">my_dic = {'AAPL':'AAPLE', 'FB':'FaceBook', 'GOOG':'Alphabet'}
+
+A dictionary is one of the most important data structures in Python. Unlike sequences which are indexed by integers, dictionaries are indexed by keys which can be either strings or floats.
+
+A dictionary is an <strong>unordered</strong> collection of key : value pairs, with the requirement that the keys are unique. We create a dictionary by placing a comma-separated list of key : value pairs within the braces.
+<pre class="prettyprint linenums">my_dic = {'AAPL': 'Apple', 'FB': 'FaceBook', 'GOOG': 'Alphabet'}
 </pre>
+
 After defining a dictionary, we can access any value by indicating its key in brackets.
 <pre class="prettyprint linenums">print my_dic['GOOG']
 [out]: Alphabet
 </pre>
+
 We can also change the value associated with a specified key:
 <pre class="prettyprint linenums">my_dic['GOOG'] = 'Alphabet Company'
 print my_dic['GOOG']
 [out]: Alphabet Company
 </pre>
+
 The built-in method of the dictionary object dict.keys() returns a list of all the keys used in the dictionary.
 <pre class="prettyprint linenums">print my_dic.keys()
 [out]: ['GOOG', 'AAPL', 'FB']
 </pre>
+
 <h2>Common String Operations</h2>
-From the content above, we know the a string is essentially an immutable sequence. It can be sliced as tuple by index.
+
+A string is an immutable sequence of characters. It can be sliced by index just like a tuple:
 <pre class="prettyprint linenums">my_str = 'Welcome to QuantConnect'
 print my_str[8:]
 [out]: to QuantConnect
 </pre>
-There are many methods associated with the string object. We can use string.count() method to count a character in a string, use string.find() to return the index of a specific character, and use string.replace() to replace characters.
+
+There are many methods associated with strings. We can use string.count() to count the occurrences of a character in a string, use string.find() to return the index of a specific character, and use string.replace() to replace characters.
 <pre class="prettyprint linenums">
-print 'Counting the number of e appears in this sentence'.count('e')
-[out]: 7
+print "Counting the number of e's in this sentence".count('e')
+[out]: 6
 print 'The first time e appears in this sentence'.find('e')
 [out]: 2
 print 'all the a in this sentence now becomes e'.replace('a','e')
 [out]: ell the e in this sentence now becomes e
 </pre>
-The most commonly used method dealing with strings is string.split(). This method will split the string by the indicated character and return a list. Here we use a real example when we build a QC algorithm:
+
+The most commonly used method for strings is string.split(). This method will split the string by the indicated character and return a list:
 <pre class="prettyprint linenums">Time = '2016-04-01 09:43:00'
 splited_list = Time.split(' ')
 date = splited_list[0]
@@ -174,18 +209,22 @@ hour = time.split(':')[0]
 print hour
 [out]: 09
 </pre>
-When we debug an algorithm, we hope to replace part of the string by our variable. This is called string formatting.
-<pre class="prettyprint linenums">my_time = 'Hour: {}, Minute:{}'.format('09','43')
+
+We can replace parts of a string by our variable. This is called string formatting.
+<pre class="prettyprint linenums">my_time = 'Hour: {}, Minute: {}'.format(9, 43)
 print my_time
-[out]: Hour: 09, Minute:43
+[out]: Hour: 9, Minute: 43
 </pre>
-An alternative formatting way is to use '%' symbol.
-<pre class="prettyprint linenums">print 'the pi number is %f'%3.14
-[out]: the pi number is 3.140000
-print '%s to %s'%('Welcome','Quantconnect')
+
+Another way to format a string is to use the % symbol.
+<pre class="prettyprint linenums">print 'pi is %f' % 3.14
+[out]: pi is 3.140000
+print '%s to %s' % ('Welcome', 'Quantconnect')
 [out]: Welcome to Quantconnect
 </pre>
-Please note that '%s' indicates that this part should be string, similarly, '%f' for float and %i' for integer.
+
+%s is a placeholder that takes in a string. Similarly %f takes a float and %d takes an integer.
+
 <h2>Summary</h2>
-We have introduced the basic data types and data structures of python. It's important to keep practicing and playing with these data structures so that you can use them flexibly. In the next tutorial we will cover for/while loop and logical operations in python, which is an essential part of programming.
-<h2></h2>
+
+We have seen the basic data types and data structures in Python. It's important to keep practicing to become familiar with these data structures. In the next tutorial, we will cover for and while loops and logical operations in Python.

--- a/Tutorial Series/Introduction to Financial Python/Tutorial02 Logical Operations and Loops.html
+++ b/Tutorial Series/Introduction to Financial Python/Tutorial02 Logical Operations and Loops.html
@@ -1,13 +1,13 @@
-<h2>Introduction</h2>
-We discussed the basic data types and data structures in Python in the last tutorial. In this chapter we will cover logical operations and loops in python, which are extremely important in programming.
-<h2>Logical Operation</h2>
-<h3>Logic Operators</h3>
-As we mentioned in the last tutorial, a boolean value is either True or False, and it can't be anything else. logical operators deal with boolean values. The operators are == (equal), != (not equal), &lt; (less than), &gt; (greater than), &lt;= (no bigger than), &gt;= (no less than).
-<pre class="prettyprint linenums">print 1 == 0
-print 1 == 1
-print 1 != 0
-print 5 &gt;= 5
-print 5 &gt;= 6
+﻿We discussed the basic data types and data structures in Python in the last tutorial. This chapter covers logical operations and loops in Python, which are very common in programming.
+
+<h2>Logical Operations</h2>
+
+Like most programming languages, Python has comparison operators:
+<pre class="prettyprint linenums">print 1 == 0    # 1 equals 0
+print 1 == 1    # 1 equals 1
+print 1 != 0    # 1 is not equal to 0
+print 5 &gt;= 5    # 5 is greater than or equal to 5
+print 5 &gt;= 6    # 5 is greater than or equal to 6
 [out]:
 False
 True
@@ -15,12 +15,19 @@ True
 True
 False
 </pre>
-We can make complex logical statements using logical operators 'and', 'or', and 'not'.
-The logic 'P and Q' is true only if both P and Q are true, otherwise this statement is False.
-The logic 'P or Q' is false only if both P and Q are false, otherwise this statement is True.
+
+Each statement above has a boolean value, which must be either True or False, but not both.
+
+We can combine simple statements P and Q to form complex statements using logical operators:
+<ul>
+    <li>The statement 'P and Q' is true only if both P and Q are true, otherwise it is False.</li>
+    <li>The statement 'P or Q' is false only if both P and Q are false, otherwise it is True.</li>
+    <li>The statement 'not P' is true if P is false, and vice versa.</li>
+</ul>
+
 <pre class="prettyprint linenums">print 2 &gt; 1 and 3 &gt; 2
 print 2 &gt; 1 and 3 &lt; 2
-print 2 &gt; 1 or 3 &lt; 2
+print 2 &gt; 1 or  3 &lt; 2
 print 2 &lt; 1 and 3 &lt; 2
 [out]:
 True
@@ -28,34 +35,36 @@ False
 True
 False
 </pre>
-If we are dealing with a very complex logical statement that involves in several statements, we can use brackets to separate and combine them.
+
+When dealing with a very complex logical statement that involves in several statements, we can use brackets to separate and combine them.
 <pre class="prettyprint linenums">print (3 &gt; 2 or 1 &lt; 3) and (1!=3 and 4&gt;3) and not ( 3 &lt; 2 or 1 &lt; 3 and (1!=3 and 4&gt;3))
 print 3 &gt; 2 or 1 &lt; 3 and (1!=3 and 4&gt;3) and not ( 3 &lt; 2 or 1 &lt; 3 and (1!=3 and 4&gt;3))
 [out]:
 False
 True
 </pre>
+
 Comparing the above two statements, we can see that it's wise to use brackets when we make a complex logical statement.
-<h3>If Statement</h3>
-An if statement let us to execute a segment of code only if the statement is true. A standard if statement contains three segments: if, elif and else.
-<pre class="prettyprint linenums">if statement1:
-    # if the statement1 is true, execute the code here.
-    # code.....
-    # code.....
-elif statement2:
-    # if the statement 1 is false, skip the codes above to this part.
-    # code......
-    # code......
+
+<h2>If Statement</h2>
+
+An if statement executes a segment of code only if its condition is true. A standard if statement consists of 3 segments: if, elif and else.
+<pre class="prettyprint linenums">if condition1:
+    # if condition1 is true, execute the code here
+    # and ignore the rest of this if statement
+elif condition2:
+    # if condition1 is false, and condition2 is true, execute the code here
+    # and ignore the rest of this if statement
 else:
-    # if none of the above statements is True, skip to this part
-    # code......
+    # if none of the above conditions is True, execute the code here
 </pre>
-An if statement doesn't necessarily has elif and else part. If it's not specified, the indented block of code will be executed when the statement is true, otherwise the whole if statement will be skipped.
+
+An if statement doesn't necessarily has elif and else part. If it's not specified, the indented block of code will be executed when the condition is true, otherwise the whole if statement will be skipped.
 <pre class="prettyprint linenums">i = 0
-if i == 0:
-    print 'i==0 is True'
+if i == 0: print 'i == 0 is True'
 [out]: i==0 is True
 </pre>
+
 As we mentioned above, we can write some complex statements here:
 <pre class="prettyprint linenums">p = 1 &gt; 0
 q = 2 &gt; 3
@@ -69,10 +78,14 @@ else:
     print 'None of p and q is true'
 [out]: q is false
 </pre>
+
 <h2>Loop Structures</h2>
-Loop is the most important part of programming. The for loop and while loop provide a way to run a block of code repeatedly.
+
+Loops are an essential part of programming. The "for" and "while" loops run a block of code repeatedly.
+
 <h3>While Loop</h3>
-A while loop will run repeatedly until a certain condition has been met.
+
+A "while" loop will run repeatedly until a certain condition has been met.
 <pre class="prettyprint linenums">i = 0
 while i &lt; 5:
     print i
@@ -84,12 +97,13 @@ while i &lt; 5:
 3
 4
 </pre>
-When making a while loop, we need to ensure that something changes from iteration to iteration so that the while loop will terminates, otherwise it will run infinitely. Here we used shorthand i += 1 (short for i = i + 1) to make i larger after each iteration. This is the most commonly used method to control a while loop.
+
+When making a while loop, we need to ensure that something changes from iteration to iteration so that the while loop will terminate, otherwise it will run forever. Here we used i += 1 (short for i = i + 1) to make i larger after each iteration. This is the most commonly used method to control a while loop.
+
 <h3>For Loop</h3>
-A for loop will iterate over a sequence of value and terminate when the sequence has ended.
-The keywords of a for loop is 'for' and 'in'.
-<pre class="prettyprint linenums">for i in [1,2,3,4,5]:
-    print i
+
+A "for" loop will iterate over a sequence of value and terminate when the sequence has ended.
+<pre class="prettyprint linenums">for x in [1,2,3,4,5]: print x
 [out]:
 1
 2
@@ -97,36 +111,39 @@ The keywords of a for loop is 'for' and 'in'.
 4
 5
 </pre>
+
 We can also add if statements in a for loop. Here is a real example from our pairs trading algorithm:
 <pre class="prettyprint linenums">stocks = ['AAPL','GOOG','IBM','FB','F','V', 'G', 'GE']
 selected = ['AAPL','IBM']
 new_list = []
-for i in stocks:
-    if i not in selected:
-        new_list.append(i)
-print stocks
-[out]: ['AAPL', 'GOOG', 'IBM', 'FB', 'F', 'V', 'G', 'GE']
+for stock in stocks:
+    if stock not in selected:
+        new_list.append(stock)
+print new_list
+[out]: ['GOOG', 'FB', 'F', 'V', 'G', 'GE']
 </pre>
+
 Here we iterated all the elements in the list 'stocks'. Later in this chapter we will introduce a smarter way to do this, which is just an one-line code.
-There are two commonly used statements in a for loop: break and continue.
-If break is encountered while a loop is executing, the loop will terminate immediately.
+
+<h3>Break and continue</h3>
+
+These are two commonly used commands in a for loop. If "break" is triggered while a loop is executing, the loop will terminate immediately:
 <pre class="prettyprint linenums">stocks = ['AAPL','GOOG','IBM','FB','F','V', 'G', 'GE']
-for i in stocks:
-    print i
-    if i == 'FB':
-        break
+for stock in stocks:
+    print stock
+    if stock == 'FB': break
 [out]:
 AAPL
 GOOG
 IBM
 FB
 </pre>
-Continue statement tells the loop to end this iteration and skip to the next iteration.
+
+The "continue" command tells the loop to end this iteration and skip to the next iteration:
 <pre class="prettyprint linenums">stocks = ['AAPL','GOOG','IBM','FB','F','V', 'G', 'GE']
-for i in stocks:
-    if i == 'FB':
-        continue
-    print i
+for stock in stocks:
+    if stock == 'FB': continue
+    print stock
 [out]:
 AAPL
 GOOG
@@ -136,8 +153,9 @@ V
 G
 GE
 </pre>
-By using break and continue, we can accomplish complex tasks in a for loop.
+
 <h2>List Comprehension</h2>
+
 List comprehension is a Pythonic way to create lists. Common applications are to make new lists where each element is the result of some operations applied to each member of another sequence. For example, if we want to create a list of squares using for loop:
 <pre class="prettyprint linenums">squares = []
 for i in [1,2,3,4,5]:
@@ -145,27 +163,32 @@ for i in [1,2,3,4,5]:
 print squares
 [out]: [1, 4, 9, 16, 25]
 </pre>
+
 Using list comprehension:
-<pre class="prettyprint linenums">list = [1,2,3,4,5]
-squares = [x**2 for x in list]
+<pre class="prettyprint linenums">foo = [1,2,3,4,5]
+squares = [x**2 for x in foo]
 print squares
 [out]: [1, 4, 9, 16, 25]
 </pre>
-Recall the example above, we used a for loop to select stock. Here we use list comprehension:
+
+Recall the example above where we used a for loop to select stocks. Here we use list comprehension:
 <pre class="prettyprint linenums">stocks = ['AAPL','GOOG','IBM','FB','F','V', 'G', 'GE']
 selected = ['AAPL','IBM']
-new_list = [x for x in stocks if x in selected]
+new_list = [x for x in stocks if x not in selected]
 print new_list
-[out]: ['AAPL', 'IBM']
+[out]: ['GOOG', 'FB', 'F', 'V', 'G', 'GE']
 </pre>
-A list comprehension consists of brackets containing an expression followed by a for clause, then zero or more for or if clauses. For example:
+
+A list comprehension consists of square brackets containing an expression followed by a "for" clause, and possibly "for" or "if" clauses. For example:
 <pre class="prettyprint linenums">print [(x, y) for x in [1,2,3] for y in [3,1,4] if x != y]
-print [str(x)+' vs '+str(y) for x in ['AAPL','GOOG','IBM','FB'] for y in ['F','V','G','GE'] if x!=y]
+print [str(x) + ' vs ' + str(y) for x in ['AAPL','GOOG','IBM','FB']
+                                for y in ['F','V','G','GE'] if x != y]
 [out]:
 [(1, 3), (1, 4), (2, 3), (2, 1), (2, 4), (3, 1), (3, 4)]
 ['AAPL vs F', 'AAPL vs V', 'AAPL vs G', 'AAPL vs GE', 'GOOG vs F', 'GOOG vs V', 'GOOG vs G', 'GOOG vs GE', 'IBM vs F', 'IBM vs V', 'IBM vs G', 'IBM vs GE', 'FB vs F', 'FB vs V', 'FB vs G', 'FB vs GE']
 </pre>
-List comprehension is an elegant way to organize one or many for loops if the purpose is to create a list.
+
+List comprehension is an elegant way to organize one or more for loops when creating a list.
+
 <h2>Summary</h2>
-In this chapter we introduced logical operation, for/while loop and list comprehension, which is an elegant and pythonic way to write a for loop inside a list. Next chapter we will introduce python functions and the concept of objective oriented programming, which will enable us to make our codes clean and versatile.
-<h2></h2>
+This chapter has introduced logical operations, loops and list comprehension. In the next chapter we will introduce functions and object-oriented programming, which will enable us to make our codes clean and versatile.

--- a/Tutorial Series/Introduction to Financial Python/Tutorial11 Linear Algebra.html
+++ b/Tutorial Series/Introduction to Financial Python/Tutorial11 Linear Algebra.html
@@ -1,6 +1,4 @@
-﻿<h2>Introduction</h2>
-
-Many papers in statistics and quantitative finance make heavy use of linear algebra, so you need to have a working knowledge of it in order to read and apply them to your trading.
+﻿Many papers in statistics and quantitative finance make heavy use of linear algebra, so you need to have a working knowledge of it in order to read and apply them to your trading.
 
 <h2>Vectors</h2>
 
@@ -11,7 +9,7 @@ x \\ y \\ z
 
 <a name="scalar"></a>
 The <strong>scalar product</strong> of two vectors \( \bm{x} \) and \( \bm{y} \) in 2-dimensional space is defined as:
-\[ \bm{x}^T \bm{y} = \begin{pmatrix} x_1 & x_2 \end{pmatrix} \begin{pmatrix} y_1 & y_2 \end{pmatrix} = x_1 y_1 + x_2 y_2 \]
+\[ \bm{x}^T \bm{y} = \begin{pmatrix} x_1 &amp; x_2 \end{pmatrix} \begin{pmatrix} y_1 &amp; y_2 \end{pmatrix} = x_1 y_1 + x_2 y_2 \]
 
 This definition can be easily generalized to <em>n</em> dimensional space. Clearly, we cannot take the scalar product of two vectors with different dimensions.
 
@@ -29,7 +27,7 @@ can be combined to produce a matrix:
 3 &amp; 1 &amp; 1
 \end{pmatrix} \]
 
-m is a 3 &times; 3 matrix. We typically describe the dimensions of a matrix as \(m \times n\) where m = number of rows and n = number of columns.
+m is a 3 &amp;times; 3 matrix. We typically describe the dimensions of a matrix as \(m \times n\) where m = number of rows and n = number of columns.
 
 A <strong>square</strong> matrix is one with as many rows as columns.
 
@@ -67,17 +65,17 @@ print matrix2
 How are two matrices multiplied? Suppose \(X = AB\). Each entry \(x_{ij}\) of matrix \(X\) is the <a href="#scalar">scalar product</a> of row \(i\) from matrix \(A\) with column \(j\) from matrix \(B\). This is best illustrated with an example:
 
 \[ AB = \begin{pmatrix}
-a_{11} & a_{12} \\
-a_{21} & a_{22} \\
-a_{31} & a_{32}
+a_{11} &amp; a_{12} \\
+a_{21} &amp; a_{22} \\
+a_{31} &amp; a_{32}
 \end{pmatrix}
 \begin{pmatrix}
-b_{11} & b_{12} \\
-b_{21} & b_{22}
+b_{11} &amp; b_{12} \\
+b_{21} &amp; b_{22}
 \end{pmatrix} = \begin{pmatrix}
-x_{11} & x_{12} \\
-x_{21} & x_{22} \\
-x_{31} & x_{32}
+x_{11} &amp; x_{12} \\
+x_{21} &amp; x_{22} \\
+x_{31} &amp; x_{32}
 \end{pmatrix} \]
 
 Then
@@ -99,7 +97,7 @@ print x
  [16 16]]
 </pre>
 
-Since matrix multiplication is defined in terms of scalar products, the matrix product \(AB\) exists only if \(A\) has as many columns as \(B\) has rows. It's useful to remember this shorthand: (m &times; n) &times; (n &times; p) = (m &times; p) which means that an (m &times; n) matrix multiplied by an (n &times; p) matrix yields an (m &times; p) matrix.
+Since matrix multiplication is defined in terms of scalar products, the matrix product \(AB\) exists only if \(A\) has as many columns as \(B\) has rows. It's useful to remember this shorthand: (m &amp;times; n) &amp;times; (n &amp;times; p) = (m &amp;times; p) which means that an (m &amp;times; n) matrix multiplied by an (n &amp;times; p) matrix yields an (m &amp;times; p) matrix.
 
 Reversing the order of multiplication results in an error since B does not have as many columns as A has rows:
 
@@ -113,11 +111,11 @@ A natrual consequence of this fact is that matrix multiplication is <strong>not 
 An <strong>identity</strong> matrix is a square matrix with ones on the main diagonal and zeros elsewhere. Here is an \(n \times n\) identity matrix:
 
 \[ I_n = \begin{pmatrix}
-   1 & 0 & 0 & ... & 0 \\
-   0 & 1 & 0 & ... & 0 \\
-   0 & 0 & 1 & ... & 0 \\
-   \vdots & \vdots & \vdots & \ddots & \vdots \\
-   0 & 0 & 0 & ... & 1
+   1 &amp; 0 &amp; 0 &amp; ... &amp; 0 \\
+   0 &amp; 1 &amp; 0 &amp; ... &amp; 0 \\
+   0 &amp; 0 &amp; 1 &amp; ... &amp; 0 \\
+   \vdots &amp; \vdots &amp; \vdots &amp; \ddots &amp; \vdots \\
+   0 &amp; 0 &amp; 0 &amp; ... &amp; 1
 \end{pmatrix} \]
 
 Multiplying any matrix by an identity matrix (of the correct shape) is like multiplying a number by 1. Concretely, if \(A\) is an \(m \times n\) matrix, then:
@@ -185,9 +183,9 @@ A common problem in linear algebra is solving linear equations. Consider the fol
 
 If we let:
 \[ A = \begin{pmatrix}
-   2  & 1  & -1 \\
-   -3 & -1 & 2  \\
-   -2 & 1  & 2
+   2  &amp; 1  &amp; -1 \\
+   -3 &amp; -1 &amp; 2  \\
+   -2 &amp; 1  &amp; 2
 \end{pmatrix} \]
 
 and
@@ -213,7 +211,7 @@ print np.dot(inv_A, b)
  [-1.]]
 </pre>
 
-The solution is <em>x</em> = 2, <em>y</em> = 3, <em>z</em> = &minus;1. However, computing the inverse matrix is not recommended, since it is numerically unstable i.e. small rounding errors can dramatically affect the result.
+The solution is <em>x</em> = 2, <em>y</em> = 3, <em>z</em> = &amp;minus;1. However, computing the inverse matrix is not recommended, since it is numerically unstable i.e. small rounding errors can dramatically affect the result.
 
 Instead, NumPy solves linear equations by <a href="https://www.youtube.com/watch?v=m3EojSAgIao" target="_blank">LU decomposition</a>:
 

--- a/Tutorial Series/Introduction to Financial Python/Tutorial12 Modern Portfolio Theory.html
+++ b/Tutorial Series/Introduction to Financial Python/Tutorial12 Modern Portfolio Theory.html
@@ -1,5 +1,4 @@
-﻿<h2>Introduction</h2>
-This chapter is about the Modern Portfolio Theory, which suggests how investors should spread their wealth across various assets to minimize risk and maximize return.
+﻿The Modern Portfolio Theory (MPT) suggests how investors should spread their wealth across various assets to minimize risk and maximize return.
 
 This chapter is mathematically intense, so don't feel demoralized if you don't understand it on your first reading.
 
@@ -21,7 +20,7 @@ The standard deviation of their payouts are:
 \[ \sigma_A = \sqrt{0.5(200-100)^2 + 0.5(0-100)^2} = 100 \]
 \[ \sigma_A = \sqrt{0.5(400-100)^2 + 0.5(-200-100)^2} = 300 \]
 
-If you are an risk seeker, you may choose asset B, because you can potentially get a higher payout. Modern Portfolio Theory assumes that investors prefer asset A since both assets have the same expected payout, but asset A has less risk.
+If you are an risk seeker, you may choose asset B, because you can potentially get a higher payout. MPT assumes that investors prefer asset A since both assets have the same expected payout, but asset A has less risk.
 
 <h2>Portfolio</h2>
 
@@ -39,14 +38,13 @@ Our <strong>expected</strong> portfolio return is
 \[ \mathbb{E}(R_P) = w_0 R_0 + w_1 \mathbb{E}(R_1) + \dots + w_n \mathbb{E}(R_n) \]
 
 Note that \( \mathbb{E}(R_0) \) is simply \( R_0 \) since the riskless return is known with certainty, by definition.
-
-<a name="correlation">
+<a name="correlation"></a>
 <h3>Correlation</h3>
 
 Before computing portfolio risk, we need to first understand covariance and correlation. They measure the linear relationship between two random variables.
 
 The covariance of two random variables X and Y is defined as
-\[ \text{Cov}(X, Y) = \mathbb{E} \left[ (X-\mathbb{E}(X)) (Y-\mathbb{E}(Y)) \right] = \mathbb{E} (XY) - \mathbb{E}(X) \mathbb{E}(Y) \]
+\[ \text{Cov}(X, Y) = \mathbb{E} \left[ (X-\mathbb{E}(X)) (Y-\mathbb{E}(Y)) \right] \]
 
 The correlation of X and Y, which is always between &minus;1 and 1, is their covariance after being standardized:
 \[ \text{Corr}(X, Y) = \text{Cov} \left( \frac{X-\mathbb{E}(X)}{\sigma_X}, \frac{Y-\mathbb{E}(Y)}{\sigma_Y} \right) = \frac{\text{Cov}(X, Y)}{\sigma_X \sigma_Y} \]
@@ -59,9 +57,9 @@ Now we are ready to compute portfolio risk, as measured by the variance of portf
 Recall that \( \text{Var}(X + c) = \text{Var}(X) \) if <em>c</em> is a known constant, so the term \( w_0 R_0 \) involving the riskless return can be omitted. It will be convenient to use <a href="https://www.mathsisfun.com/algebra/sigma-notation.html" target="_blank">sigma notation</a>:
 
 \[ \begin{align*}
-\text{Var}(R_P) &= \text{Var} \left( \sum_{k=1}^n w_k R_k \right) \\
-&= \mathbb{E} \left[\left( \sum_{k=1}^n w_k R_k - \mathbb{E} \left( \sum_{k=1}^n w_k R_k \right) \right)^2\right] \\
-&= \mathbb{E} \left[\left( \sum_{k=1}^n w_k \, \left( R_k - \mathbb{E}(R_k) \right) \right)^2\right]
+\text{Var}(R_P) &amp;= \text{Var} \left( \sum_{k=1}^n w_k R_k \right) \\
+&amp;= \mathbb{E} \left[\left( \sum_{k=1}^n w_k R_k - \mathbb{E} \left( \sum_{k=1}^n w_k R_k \right) \right)^2\right] \\
+&amp;= \mathbb{E} \left[\left( \sum_{k=1}^n w_k \, \left( R_k - \mathbb{E}(R_k) \right) \right)^2\right]
 \end{align*} \]
 
 So we must square a sum of <em>n</em> terms... How?
@@ -72,8 +70,8 @@ If we expand the brackets on the right hand side, every term has the form \( u_i
 
 Therefore
 \[ \begin{align*}
-\text{Var}(R_P) &= \mathbb{E} \left[ \sum_{i=1}^n \sum_{j=1}^n w_i \, w_j \, (R_i - \mathbb{E}(R_i)) (R_j - \mathbb{E}(R_j)) \right] \\
-&= \sum_{i=1}^n \sum_{j=1}^n w_i \, w_j \, \text{Cov}(R_i, R_j)
+\text{Var}(R_P) &amp;= \mathbb{E} \left[ \sum_{i=1}^n \sum_{j=1}^n w_i \, w_j \, (R_i - \mathbb{E}(R_i)) (R_j - \mathbb{E}(R_j)) \right] \\
+&amp;= \sum_{i=1}^n \sum_{j=1}^n w_i \, w_j \, \text{Cov}(R_i, R_j)
 \end{align*} \]
 
 The last step arises from the definition of <a href="#correlation">covariance</a>. The only thing left is to express portfolio risk in matrix notation:

--- a/Tutorial Series/Introduction to Financial Python/Tutorial13 Capital Asset Pricing Model.html
+++ b/Tutorial Series/Introduction to Financial Python/Tutorial13 Capital Asset Pricing Model.html
@@ -1,69 +1,92 @@
-In the last chapter we introduced modern portfolio theory and some very important concepts, which include portfolio variance, sharpe ratio, diversification, tangent portfolio, capital market line. In this chapter we will continue from the modern portfolio theory world and consider asset pricing.
-<h2>CAPM</h2>
-You maybe confused with the term 'asset pricing'. For any securities, 'price' and 'return' are the same thing, they just like the two faces of a coin. <strong>Capital Asset Pricing Model (CAPM)</strong> is the most classical model for asset pricing.
+﻿In the financial literature, you may hear terms like the "beta" or "market risk" of an asset. This chapter will explain where these terms come from and how they can be useful.
 
-Let's start from what we have learned.
+<h2>Capital Asset Pricing Model (CAPM)</h2>
+
+As we shall see later, the name "Asset Pricing" is a bit misleading because the CAPM tells us the expected return, rather than the price, of an asset.
+
+In the last chapter, we introduced the Capital Market Line (CML) shown in black:
 
 <img class="aligncenter size-full wp-image-2154" src="https://www.quantconnect.com/tutorials/wp-content/uploads/2017/07/Unknown-2.png" alt="" width="1184" height="592" />
-In the last chapter we learned that all the investor should hold the securities on the capital market line(the red line above). We also know that all the assets on this line has the same sharpe ratio. for any two assets:
-\[SR =\frac{ r_i - r_f}{\sigma_i} = \frac{ r_j - r_f}{\sigma_j}\]
-This should also hold for the market portfolio, so we replace asset j with the market portfolio:
-\[SR =\frac{ r_i - r_f}{\sigma_i} = \frac{ r_m - r_f}{\sigma_m}\]
-We change the form of the above equation:
-\[r_i =r_f + \frac{\sigma_i}{\sigma_m} (r_m - r_f)\]
-We know that all the asset on the capital asset line is a two-asset portfolio consist with risk-free asset and market portfolio, thus the correlation of the portfolio i and the market portfolio must be 1 (perfect linear relation). We multiply the the numerator and the denominator of the second term at the same time:
-\[r_i =r_f + \frac{\rho \sigma_m\sigma_i}{\sigma_m^2} (r_j - r_j) = r_f + \frac{Cov_{i,m}}{Var_m} (r_j - r_j)\]
-If you are familiar enough with simple linear regression, you will found that If we set \(r_i-r_f\) as y, and \(r_m - r_f\) as x, the slope, or coefficient of this simple linear regression, \(\beta\), is:
-\[\beta = \frac{Cov_{i,m}}{Var_m}\]
-We use \(\beta\) to replace this term:
-\[r_i - r_f = \beta(r_m - r_f) + \epsilon\]
-This is the <strong>Capital Asset Pricing Model (CAPM)</strong>, where \(\alpha\) is the so called <strong> Jensen's alpha</strong> and \(\epsilon\) is the regression residual. In a Perfect CAPM world, all of the return can be explained by the model, so the \(\alpha\) should be zero.
-<h2>Beta</h2>
-In CAPM, beta is a synonym of 'risk'. This can be seen from the formula given below:
-\[\beta = \frac{\rho\sigma_m\sigma_p}{\sigma_m^2} = \frac{\rho\sigma_p}{\sigma_m}\]
-Under the CAPM assumption, All of the securities should lie on the capital allocation line, thus the correlation \(\rho\) should be 1. Beta represents the systematic risk that can not be diversified away because it is the exposure to the market.
 
-More straightforwardly, beta can be considered the relationship between the asset return and market return. If asset A has a beta of 1.2, that means when the market goes up 1%, the asset goes up 1.2%, and if the market goes down 1%, the asset would goes down 1.2%.
-<h3>Beta Computing in Practice</h3>
-The formula for the Capital Asset Pricing Model looks easy, but we have a lot of factors to consider when we use it in practice. We first need to choose the return period we use to computer the rate of return: We should use daily return, weekly return or monthly return? Then we need to consider the number of data points we use for the regression. If we use monthly return in the past one year to computer the beta, or use daily return to computer the beta in one month, neither of them make sense because the samples' size are too small.
+All investors should hold a portfolio on the CML, which is constructed by investing some fraction <em>w</em> of our wealth in the market portfolio and the remainder (1 &minus; <em>w</em>) in the riskless asset. So the return on a CML portfolio is
+\[ R = w R_{\text{market}} + (1-w) R_0 \]
 
-In the real world, beta is not unchanged for a given asset. The following plot is the daily rolling beta of GE stock with a 6-month rolling windows:
+If we let &beta; = w, then the equation above becomes
+\[ R - R_0 = \beta (R_{\text{market}} - R_0) \]
+
+Notice that &beta; is a measure of how sensitive our CML portfolio return is to the market return. Taking expectation on both sides results in the CAPM:
+\[ \mathbb{E}(R) - R_0 = \beta (\mathbb{E} (R_{\text{market}}) - R_0) \]
+
+Taking covariance on both sides instead yields
+\[ \text{Cov} (R - R_0, R_{\text{market}}) = \beta \text{Cov} (R_{\text{market}} - R_0, R_{\text{market}}) \]
+
+Now apply two basic facts about covariance:
+<ul>
+    <li>\( \text{Cov} (X + c, Y) = \text{Cov} (X, Y) \) where \( c \) is constant</li>
+    <li>\( \text{Cov} (X, X) = \text{Var} (X) \)</li>
+</ul>
+
+Hence we obtain
+\[ \beta = \frac {\text{Cov} (R, R_{\text{market}})} {\text{Var} (R_{\text{market}})} \]
+
+<h2>Computing &beta; in Practice</h2>
+
+While the Capital Asset Pricing Model is straightforward, applying it may not be. We first need to choose the timeframe for computing returns: should we use daily, weekly or monthly returns? Then we need to consider the number of data points available for linear regression. For example, if we compute beta using monthly returns in the past 1 year, then we only have 12 data points which is too few.
+
+Furthermore, the &beta; of an asset can change over time. The following plot is the daily rolling beta of GE stock with a 6-month rolling windows:
+
 <img class="aligncenter size-full wp-image-2161" src="https://www.quantconnect.com/tutorials/wp-content/uploads/2017/07/Unknown-3.png" alt="" width="1156" height="558" />
-As you can see, the beta of this asset ranged approximately from 0.1 to 0.5, which is a very wide range! This is the reason why you need to be careful when using beta. It makes no sense to talk about beta without resolution and computing period.
+
+The &beta; of GE ranged from 0.1 to 0.5 approximately. This is why you need to be careful when using &beta;. It makes no sense to talk about &beta; without a timeframe in mind.
+
 The following graph is the rolling p-value of beta. The p-value stays close to zero most of the time. However, during some period it suddenly increased close to 0.1, which corresponds to a 90% confidence interval. This might be caused by some mispricing or market turmoil.
+
 <img class="aligncenter size-full wp-image-2164" src="https://www.quantconnect.com/tutorials/wp-content/uploads/2017/07/Unknown-4.png" alt="" width="1163" height="558" />
-<h3>Market-neutral</h3>
-A portfolio is considered to be <strong>Market Neutral</strong> if it seeks to avoid the market risk. Some classical market-neutral strategies are pairs trading, beta-hedged equity portfolio and other derivatives strategies.
 
-Technically speaking, market neutral means totally the portfolio's beta is zero. This means the portfolio's return would not be affected by the market return. A market-neutral portfolio is usually construct by long/short because most of the fundamental assets have positive betas. Here we try to construct a simple market-neutral portfolio by hedging out beta.
+<h2>Market-Neutral</h2>
 
-We used Dow 30 companies as out stock universe. The idea is straightforward: we calculate the rolling beta of each stock, and find the stocks who's rolling beta is highly correlated with each other. If we can find the linear relationship between two rolling betas, we can cancel out the portfolio's beta by long and short.
+A portfolio is market-neutral if its <strong>&beta; is zero</strong>. In other words, the portfolio's returns are uncorrelated with market returns. We say that it has no "market risk". Some classical market-neutral strategies are pairs trading, beta-hedged equity portfolio and other derivatives strategies.
 
-Let's say we have stock A and stock B, given that:
-\[r_A = r_f + \beta_A(r_m - r_f)\]
-\[r_B = r_f + \beta_B(r_m - r_f)\]
-Although \(\beta_A\) and \(\beta_B\) are always changing, as long as we can find the linear relationship between them, we can construct a market-neutral portfolio. If:
-\[\beta_B = a + b\beta_A\]:
-Replacing \(\beta_B\) with \(\beta_A\):
-\[r_B = r_f = (a + b\beta_A)*(r_m - r_f)\]
-Let's allocate \(w_A\) on stock A and \(w_B\) on stock B, we only need to solve two linear equations:
-\[w_A + w_B = 1\]
-\[w_A + b*w_B = 0\]
-As you may noticed, we are not perfectly hedging here because the exists of the intercept \(\a\). If the significance level of \(\a\) is low or the value of it is small enough to be neglected, we can achieve our goal by just using two stocks. Otherwise we need to use three stocks to cancel out the intercept amount of the market risk. Anyway we by using two asset we have already hedged out most of the market risk exposure.
+We have daily returns of Dow 30 stocks from March 2012 to Jan 2015. For each stock, its &beta; on any given day is computed using the past 6 months' returns. As this 6-month window moves forward in time, &beta; will of course change.
 
-We used daily return data from March 2012 to Jan 2015, which is an approximately two year in sample period. After calculating the daily rolling beta with a 6-month rolling windows length, we drew the correlation chart of their rolling betas:
+Once we know how each stock's &beta; has changed over time, we can ask: which stocks' betas are correlated with each other? The table below shows the correlation between each stock's beta.
+
 <img src="https://www.quantconnect.com/tutorials/wp-content/uploads/2017/07/Unknown-5.png" alt="" width="1056" height="578" class="aligncenter size-full wp-image-2174" />
-We selected PG and KO stocks, who's rolling betas have a correlation of 0.95.
-We use OLS regression to find the relationship between two beta. The model shows that:
-\[\beta_{KO} = -0.0097 + 0.969\beta_{PG}\]
-With 57.98 t-stats score on beta and 0.87 r-squared. We confirm that there exist linear relationship.
-After solving the linear equations demonstrated above, we obtained the hedge weight:
-\[w_{KO} = -24\]
-\[w_{PG} = 25\]
-We scaled the weight by dividing all of the weights by 25, we got \(w_{KO} = -0.48\) and \(w_{PG} = 0.5\). We test this portfolio both in sample and out of sample, and it achieved a beta of 0.01 and -0.004. The two backtesting results are attached at the end.
+
+How can we construct a market-neutral portfolio? Consider two stocks A and B:
+\[ R_A = R_0 + \beta_A (R_{\text{market}} - R_0) \]
+\[ R_B = R_0 + \beta_B (R_{\text{market}} - R_0) \]
+
+Let's allocate <em>w</em> on stock A and (1 &minus; <em>w</em>) on stock B, then market neutrality means
+\[ w\beta_A + (1-w) \beta_B = 0 \qquad \Rightarrow \qquad
+   w = \frac{\beta_B}{\beta_B - \beta_A} \]
+
+As mentioned earlier, \(\beta_A\) and \(\beta_B\) will change with time, so will \(w\) in a market-neutral portfolio. However we can achieve market neutrality with constant \(w\) so long as \(\beta_A\) and \(\beta_B\) have a linear relationship:
+\[ \beta_A = m\beta_B + c \]
+
+Then eliminate \(\beta_A\) to get
+\[ w = \frac{\beta_B}{(1-m) \beta_B - c} \]
+
+If <em>c</em> &approx; 0 then <em>w</em> is roughly constant:
+\[ w = \frac{1}{1-m} \]
+
+Note: If <em>c</em> is signficant, then we need 3 stocks to get zero net beta. Usually 2 stocks are sufficient to cancel out most of the market risk.
+
+<h3>Example</h3>
+
+The 6-month rolling betas of PG and KO stocks have a correlation of 93%. The linear relationship between their betas is
+\[ \beta_{KO} = -0.0097 + 0.969 \beta_{PG} \]
+
+Therefore the market neutral weights are
+\[ w_{KO} = \frac{1}{1-0.969} = 32.3 \qquad w_{PG} = 1 - w_{KO} = -31.3 \]
+
+We tested this portfolio both in-sample (March 2012 to Jan 2015) and out-of-sample. It achieved a beta of 0.01 and -0.004 respectively. See the backtest below.
 
 <h2>Summary</h2>
-In this chapter we deduced the Capital Asset Pricing Model formula from the modern portfolio theory, and show some practice to build a market-neutral portfolio. In the next chapter we will expand CAPM into multi-factor models, which include the most commonly used Fama-French 3 factor and 5 factor models.
+
+This chapter has explained what market risk means in the context of CAPM, and how market risk can be reduced. In the next chapter we will generalize CAPM to multi-factor models, such as the Fama-French models.
+
 <h2>Algorihtm</h2>
+
 <script src='https://www.quantconnect.com/terminal/backtest.js?sid=8bac244b346cbd9bc3b39dca76192919'></script>
 <script src='https://www.quantconnect.com/terminal/backtest.js?sid=5c75197259238b36a6cea72832c9e709'></script>

--- a/Tutorial Series/Introduction to Financial Python/Tutorial14 Fama-French Multi-Factor Models.html
+++ b/Tutorial Series/Introduction to Financial Python/Tutorial14 Fama-French Multi-Factor Models.html
@@ -1,76 +1,96 @@
-<h2>Introduction</h2>
-In the last chapter we introduced Capital Asset Pricing Model(CAPM), which used market return as a factor to explain the return of the measured asset. In this chapter we will expand the single-factor model into multi-factor models, which use more factor to price an asset. Multi-factor models can be written in the following forms:
-\[r_A = \alpha + \beta_1f_1 + \beta_2f_2 + \beta_3f_3 +...+\beta_nf_n\]
-Where \(f_i\) is the factor \(i\) and \(\beta_i\) is the coefficient, or beta of factor \(i\).
+﻿In previous chapters, we learnt that the Capital Asset Pricing Model (CAPM) treats the market return as the only factor affecting the return of any asset. This chapter will generalize CAPM to multi-factor models of the following form:
+\[ R = \alpha + \beta_1 f_1 + \beta_2 f_2 + \dots + \beta_n f_n \]
+where each \(f_i\) is a factor.
+
 <h2>Fama-French Three-Factor Model</h2>
-This factor is designed by <strong>Eugene Fama</strong> and <strong>Kenneth French</strong> to describe stock returns. They proposed this model in their research in 1993,[ref] <strong>Fama, E. F.; French, K. R.</strong> (1993). "Common risk factors in the returns on stocks and bonds". Journal of Financial Economics. 33: 3. CiteSeerX 10.1.1.139.5892 Freely accessible. doi:10.1016/0304-405X(93)90023-5[/ref] and thereafter this model are commonly used to replace CAPM.
 
-The model is given by:
-\[r = \alpha + \beta_mMKT + \beta_sSMB + \beta_hHML + \epsilon\]
-Where \(MKT\), \(SMB\) \(HML\) are the three factors.
+This model was proposed in 1993 by <strong>Eugene Fama</strong> and <strong>Kenneth French</strong> to describe stock returns.[ref] <strong>Fama, E F; French, K R</strong> (1993). Common risk factors in the returns on stocks and bonds. Journal of Financial Economics. 33: 3. CiteSeerX 10.1.1.139.5892 Freely accessible. doi:10.1016/0304-405X(93)90023-5[/ref]
 
-\(MKT\) is the market factor and it represents the excess return on the market[ref]Kenneth's Website <a href="http://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/f-f_factors.html">Link</a>[/ref]. It's a value-weight return of all CRSP firms incorporated in the US and listed on the NYSE, AMEX, or NASDAQ minus the one-month Treasure bill rate.
+The 3-factor model is
+\[ R = \alpha + \beta_m MKT + \beta_s SMB + \beta_h HML \]
 
-\(SMB\) is short for 'Small Minus Big', which represents the small cap stocks beat the large cap stocks.
+where
+<ul>
+    <li>MKT is the excess return of the market.[ref]<a href="http://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/f-f_factors.html" target="_blank">mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/f-f_factors.html</a>[/ref] It's the value-weighted return of all CRSP firms incorporated in the US and listed on the NYSE, AMEX, or NASDAQ minus the 1-month Treasury Bill rate.</li>
+    <li>SMB (Small Minus Big) measures the excess return of stocks with small market cap over those with larger market cap.</li>
+    <li>HML (High Minus Low) measures the excess return of value stocks over growth stocks. Value stocks have high book to price ratio (B/P) than growth stocks.</li>
+</ul>
 
-\(HML\) is short for 'High Minus Low'. It represents the stocks with high B/P values(book value to market price) outperform the stocks with low B/P values. The high B/P stocks are also called <strong>"value stocks".</strong> Correspondently, the low B/P ones are called <strong>"growth stocks"</strong>.
+Data on these factors can be downloaded from <a href="http://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/f-f_factors.html" target="_blank">French's website</a>.
 
-The details of how these factors are calculated can be found on<a href="http://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/f-f_factors.html"> Kenneth's website</a>. This is also the source of the Fama-French factors.
 <h2>Model test</h2>
-In order to test the model significance and the economics intuition behind it, we used NASDAQ US Small Cap Index and NASDAQ US Large Cap Index to fit the three-factor model. We used daily data in the past six years to do the regression.
-The following table is the regression results from the small caps:
-<img class="aligncenter size-full wp-image-2206" src="https://www.quantconnect.com/tutorials/wp-content/uploads/2017/08/Screen-Shot-2017-08-01-at-5.20.02-PM.png" alt="" width="1342" height="830" />As we expected, the exposure to, or the coefficient of the SMB factor is positive, which means when the small stocks beat the large stocks, it positively contributes to the return. Compared with the HML factor, the absolute values of factor MKT and SMB are obviously larger. Given that the values of the three factor are under the same scale, we know that MKT and SMB are the decisive factors for the small cap index.
 
-&nbsp;
+To test the 3-factor model, we use it to predict returns on NASDAQ US Small Cap Index and NASDAQ US Large Cap Index. We estimate the model with daily returns in the past 6 years.
 
-Now let's check the result for large caps below:
+Results for US Small Cap returns:
+<img class="aligncenter size-full wp-image-2206" src="https://www.quantconnect.com/tutorials/wp-content/uploads/2017/08/Screen-Shot-2017-08-01-at-5.20.02-PM.png" alt="" width="1342" height="830" />
 
+The coefficient of SMB is positive, so when small caps outperform large caps, the Small Cap Index will have higher returns, which is not surprising. By comparing the t statistics of those factors, we know that MKT and SMB are more important factors driving the Small Cap Index.
+
+Results for US Large Cap returns:
 <img class="aligncenter size-full wp-image-2205" src="https://www.quantconnect.com/tutorials/wp-content/uploads/2017/08/Screen-Shot-2017-08-01-at-5.18.48-PM.png" alt="" width="1346" height="822" />
 
-Not surprisingly, The SMB factor is negative for the large cap index. The reason is straightforward: when small stocks outperform big stocks, the big stocks performs relatively bad thus the index has a lower return. The coefficient of HML factor is still very low, the reason is the value stocks and growth stocks takes approximately the same weight in the index portfolio.
-<h2>Risk Premia</h2>
-What if we want to know know the return on a single factor? We can achieve this purpose by construct a <strong>tracking portfolio</strong>. For example, if we want a tracking portfolio of the HML factor, we only need to find 4 stocks to construct a portfolio that has zero coefficients on the MKT and SMB factor and 1 coefficient on the HML factor. Generally, if we have stock A, B, C, and D, who's return can be explain by the three factor model:
-\[r_A = \alpha_A + \beta_{11}MKT + \beta_{12}SMB + \beta_{13}HML\]
-\[r_B = \alpha_B + \beta_{21}MKT + \beta_{22}SMB + \beta_{23}HML\]
-\[...\]
-And their weight in the portfolio are represented by \((w_A,w_B,w_C,w_D\)). We write the coefficients into a matrix:
-\[\Sigma = \begin{pmatrix}
-\alpha_{1} &amp; \beta_{11}&amp;\beta_{12}&amp;\beta_{13} \\
-\alpha_{2} &amp;\beta_{21}&amp;\beta_{22}&amp;\beta_{23} \\
-\alpha_{3}&amp;\beta_{31}&amp;\beta_{32}&amp;\beta_{33}\\
-\alpha_{4}&amp;\beta_{41}&amp;\beta_{42}&amp;\beta_{43}
-\end{pmatrix}\]
-We just need to solve the following linear equations:
-\[w\Sigma = \begin{pmatrix}
-0\\0\\0\\1
-\end{pmatrix}\quad\]
-By constructing a tracking portfolio, we can track a specific factor's return. Subtracting risk-free rate from the return, we get <strong>risk premia</strong> of this factor.
+As expected, the coefficient of SMB is negative for the Large Cap Index. The coefficient of HML is quite low, which suggests that value and growth stocks take approximately the same weight in the Large Cap Index.
 
-Economically, any idiosyncratic risk, or firm specified risk, can be diversified away. The Market risk in CAPM, and the exposure to the three FF factor in the multi-factor model, are systematic risk which can't be diversified away. Risk premia of a factor measure the risk premium above the risk-free for the investor to take this risk.
+<h2>Factor Returns</h2>
+
+How do we find out the returns on a single factor? We can do so by constructing a <strong>tracking portfolio</strong> and computing its returns. For example, if we want a tracking portfolio of the HML factor, we only need to find 4 stocks to construct a portfolio that has MKT and SMB coefficients of 0 and HML coefficient of 1.
+
+Consider stocks A, B, C, and D whose returns can be explained by the 3-factor model:
+
+\[ R_A = \alpha_1 + \beta_{11} MKT + \beta_{12} SMB + \beta_{13} HML \]
+\[ R_B = \alpha_2 + \beta_{21} MKT + \beta_{22} SMB + \beta_{23} HML \]
+\[ \vdots \]
+
+Let their weights in the tracking portfolio be \(w_A,w_B,w_C,w_D\). We write the coefficients into a matrix:
+\[ \Sigma = \begin{pmatrix}
+   \alpha_1 &amp; \beta_{11} &amp; \beta_{12} &amp; \beta_{13} \\
+   \alpha_2 &amp; \beta_{21} &amp; \beta_{22} &amp; \beta_{23} \\
+   \alpha_3 &amp; \beta_{31} &amp; \beta_{32} &amp; \beta_{33} \\
+   \alpha_4 &amp; \beta_{41} &amp; \beta_{42} &amp; \beta_{43}
+\end{pmatrix} \]
+
+The tracking portfolio is determined by the solution to these linear equations:
+\[ w^T \Sigma = \begin{pmatrix} 0 \\ 0 \\ 0 \\ 1 \end{pmatrix} \]
+
+Economic interpretation: The 3 Fama-French factors represent "systematic risk" which cannot be reduced by diversification. Investors earn those factor returns for taking such risks. Any idiosyncratic risk, or firm-specific risk, can be diversified away and so investors are not paid to take such risks.
+
 <h2>Other Factors</h2>
-Although the FF three factors are the most import factors(by far), there are still some popular factors.
 
-Momentum is a commonly used one, which represents 'winners' significantly outperform 'losers'.
+The Fama-French 5-Factor model comprises two more factors:
+<ul>
+    <li>RMW (Robust Minus Weak) measures the excess returns of firms with high operating profit margins over those with lower profits.</li>
+    <li>CMA (Conservative Minus Aggressive) measures the excess returns of firms investing less over those investing more.</li>
+</ul>
 
-Profitability is another factor proposed by Novy-Marx(2013)[ref]<strong>Robert Novy-Marx(2013)</strong> The Other Side of Value: The Gross Profitability Premium Journal of Financial Economics 108 (1), 1-28 <a href="http://rnm.simon.rochester.edu/research/OSoV.pdf">Online Copy</a>[/ref]. It represents the firms with high operating profit margin outperform the less profitable firms. ' Controlling for gross profitability explains most earnings related anomalies, and a wide range of seemingly unrelated profitable trading strategies'. Nove-Marx explained this factor in his paper. Now the profitability has been incorporated in the 'Fama-French empirical 5-factor model', and this factor is called 'RMW'(robust minus weak).
+RMW was proposed by Novy-Marx (2013)[ref]<strong>Robert Novy-Marx (2013)</strong> The Other Side of Value: The Gross Profitability Premium Journal of Financial Economics 108 (1), 1-28. Retrieved from <a href="http://rnm.simon.rochester.edu/research/OSoV.pdf" target="_blank">rnm.simon.rochester.edu/research/OSoV.pdf</a>[/ref] who wrote that:
 
-Another factor in the 5-factor model is CMA(conservative minus aggressive). It represents the firms investing less(conservative) outperform the firms investing a lot. Fama and French(2014)[ref]<strong>Fama, E. F.; French, K. R. (2015)</strong>.A Five-Factor Asset Pricing Model. 116: 1–22. doi:10.1016/j.jfineco.2014.10.010 <a href="https://www8.gsb.columbia.edu/programs/sites/programs/files/finance/Finance%20Seminar/spring%202014/ken%20french.pdf">Online Copy</a>[/ref] pointed out in their paper that 'A five-factor model directed at capturing the size, value, profitability, and investment patterns in average stock returns is rejected on the GRS test, but for applied purposes it provides an acceptable description of average returns'.
-This means the SMB, HML, RMW and CMA factors capture size, value, profitability and investment pattern respectively. This made the FF 5 factor-model the latest and one of the most powerful asset pricing model so far.
+<blockquote>"Controlling for gross profitability explains most earnings related anomalies, and a wide range of seemingly unrelated profitable trading strategies."</blockquote>
+
+CMA was proposed by Fama and French (2014)[ref]<strong>Fama, E F; French, K R (2015)</strong>. A Five-Factor Asset Pricing Model. 116: 1–22. doi:10.1016/j.jfineco.2014.10.010. Retrieved from <a href="https://www8.gsb.columbia.edu/programs/sites/programs/files/finance/Finance%20Seminar/spring%202014/ken%20french.pdf" target="_blank">www8.gsb.columbia.edu/programs/sites/programs/files/finance/Finance%20Seminar/spring%202014/ken%20french.pdf</a>[/ref] who pointed out that:
+
+<blockquote>"A five-factor model directed at capturing the size, value, profitability, and investment patterns in average stock returns is rejected on the GRS test, but for applied purposes it provides an acceptable description of average returns."</blockquote>
+
+Finally, momentum is another commonly used factor. It captures excess returns of stocks with highest returns over those with lowest returns
+
 <h2>Summary</h2>
-In this chapter we expand Capital Asset Pricing Model(CAPM) into multi-factor models, and introduced Fama-French factor models, which are the most empirically successful multi-factor models by far, and they are commonly used both in practice and in academic.
+
+In this chapter we expand Capital Asset Pricing Model (CAPM) into multi-factor models: the Fama-French factor models in particular. They are the most empirically successful multi-factor models by far, and are commonly used in practice.
+
 <h2>Algorithm</h2>
-Multi-factor strategies are usually <strong>stock picking</strong> strategy. Here we try to implement a paper published by AQR Capital Management in 2013: A New Core Equity Paradigm.[ref]<strong>AQR</strong>: A New Core Equity Paradigm: Using Value, Momentum, and Quality to Outperform Markets.<a href="https://www.aqr.com/~/media/files/papers/aqr-a-new-core-equity-paradigm.pdf ">Online Copy</a>[/ref]
 
-The main idea of the paper is to pick stocks by their value, quality and momentum.
+Multi-factor strategies are <strong>stock picking</strong> strategies. Here we try to implement a 2013 paper published by AQR Capital Management.[ref]<strong>AQR (2013)</strong>. A New Core Equity Paradigm: Using Value, Momentum, and Quality to Outperform Markets. Retrieved from <a href="https://www.aqr.com/~/media/files/papers/aqr-a-new-core-equity-paradigm.pdf" target="_blank">www.aqr.com/~/media/files/papers/aqr-a-new-core-equity-paradigm.pdf</a>[/ref]
 
-The empirically successful measure of value is book-to-price(B/P), but the paper points out that other measures can be used and applied simultaneously to form a more robust and reliable view of a stock's value. The paper uses five measures: book-to-price, earnings-to-price(EPS), forecasted EPS, Cash flow-to-enterprise value and sales-to-enterprise value.
+The paper recommends picking stocks by their value, quality (profitability) and momentum.
 
-Quality means profitability. Similarly, the paper used multiple quality measures - total profit over assets, gross margin and free cash flow over assets - to capture different aspects of a firm's profitability.
+The empirically successful measure of value is book-to-price ratio (B/P), but other measures can be used simultaneously to form a more robust and reliable view of a stock's value. The paper uses 5 measures: book-to-price, earnings-to-price ratio (EPS), forecasted EPS, cash flow-to-enterprise value and sales-to-enterprise value.
 
-The measures of momentum can also be diversified. One-year momentum, fundamental momentum and returns around earning announcement are good choices.
+The paper suggested a few quality measures: total profit over assets, gross margin and free cash flow over assets.
 
-For our demonstrated strategy, we chose Operation margin for quality, P/B value for profitability and 1-month momentum. The Portfolio was rebalanced every two months and our backtest period is from Jan, 2012 to Jan, 2015.
+There are also various measures of momentum. 1-year momentum, fundamental momentum and returns around earnings announcement are good choices.
 
-You can build your own version by changing the factor, the weight of each factor, and the rebalance period based on the demonstrated strategy.
+In our backtested strategy, we used operating profit margin to measure quality, P/B value to measure value, and 1-month momentum. The portfolio was rebalanced every 2 months and our backtest period runs from Jan 2012 to Jan 2015.
+
+You can build your own version by changing the factor, the weight of each factor, and the rebalance period based on the backtested strategy.
 
 <script src='https://www.quantconnect.com/terminal/backtest.js?sid=b4984b5b8c44359422f063c46ebacc2e'></script>


### PR DESCRIPTION
In all tutorials, the "Introduction" heading is removed since the first paragraph is clearly an introduction.

**CAPM tutorial**
I suggest changing its title from "Capital Asset Pricing Model" to "Market Risk" because the first heading is already CAPM.
Sharpe ratio has been omitted from the CAPM tutorial to be consistent with the Portfolio Theory tutorial.

> We scaled the weight by dividing all of the weights by 25, we got w_{KO} = -0.48 and w_{PG} = 0.5

Weights must sum to 1, but −0.48 + 0.5 = 0.02 doesn't.

Side note: If you regress β_PG against β_KO instead, then the coefficient of β_KO may not be 1 / 0.969 so the weights may depend on which way you regress those betas.