### PR TITLE
Change Symbol GOOG to AAPL - fixes typo

### DIFF
--- a/06 Introduction to Options[]/01 General Features of Options/04 The Value of Options.html
+++ b/06 Introduction to Options[]/01 General Features of Options/04 The Value of Options.html
@@ -12,5 +12,5 @@
 \[Time Value= Premium-Intrinsic Value\]
 </div>
 <p>
-For example, an AAPL call option contract which expires after 10 days has strike $143 and premium $10. now the market price of GOOG is $160. The intrinsic value of this contract is 160-143=$17, the time value is 17-10=$7. Although the intrinsic value of OTM and ATM options is zero, they have time values if they still have a certain amount of time until the option expires so for OTM and ATM options, their premiums equal their time values.
+For example, an AAPL call option contract which expires after 10 days has strike $143 and premium $10. now the market price of AAPL is $160. The intrinsic value of this contract is 160-143=$17, the time value is 17-10=$7. Although the intrinsic value of OTM and ATM options is zero, they have time values if they still have a certain amount of time until the option expires so for OTM and ATM options, their premiums equal their time values.
 </p>


### PR DESCRIPTION
In this simple example on how to compute intrinsic value and time value of a single option, two different symbols are used, which is confusing, and I am pretty sure it's just typo.  Simply change GOOG to AAPL