### PR TITLE
Fix typos in Rate of Return, Mean and Variance tutorial

### DIFF
--- a/05 Introduction to Financial Python[]/06 Rate of Return, Mean and Variance/02 Rate of Return.html
+++ b/05 Introduction to Financial Python[]/06 Rate of Return, Mean and Variance/02 Rate of Return.html
@@ -41,7 +41,7 @@ print rate_return
 </p>
 <h4>Logarithm Return</h4>
 <p>
-  In the above example, strategy A has 6% return over three months. Nominally, the annual return would be 3*6% = 18%.
+  In the above example, strategy A has 6% return over three months. Nominally, the annual return would be 4*6% = 24%.
   This nominal annual interest rate is called the stated annual interest rate.
   It is calculated as the periodic interest rate times the number of periods per year. It works according to the simple interest and does not take into account the compounding periods, while the effective annual interest rate is 26% as we calculated above and it does account for intra-year compounding.
   The effective annual interest rate is an essential tool that allows the evaluation of the real return on investment.

--- a/05 Introduction to Financial Python[]/06 Rate of Return, Mean and Variance/05 Summary.html
+++ b/05 Introduction to Financial Python[]/06 Rate of Return, Mean and Variance/05 Summary.html
@@ -1,3 +1,3 @@
 <p>
-  We introduced different types of rate of return in this chapter, which could be a little bit tricky when we calculate them. Mean and standard deviation are also very important concepts when we conduct hypothesis test or measure the risk associated with a asset. We will use those comcepts intensively in our later chapter.
+  We introduced different types of rate of return in this chapter, which could be a little bit tricky when we calculate them. Mean and standard deviation are also very important concepts when we conduct hypothesis test or measure the risk associated with a asset. We will use those concepts intensively in our later chapter.
 </p>


### PR DESCRIPTION
Fixed a sentence that incorrectly calculated the annual nominal return from a 6% return over three months by multiplying by 3 instead of 4.

Corrected misspelling of the word "concepts."