### PR TITLE
Codes fixed in tutorial strategy

### DIFF
--- a/04 Strategy Library/27 Momentum Effect in Commodities Futures/02 Method.html
+++ b/04 Strategy Library/27 Momentum Effect in Commodities Futures/02 Method.html
@@ -14,7 +14,7 @@ for symbol in self.symbols:
 
 class QuandlFutures(PythonQuandl):
     def __init__(self):
-        self.ValueColumnName = "settle"
+        self.ValueColumnName = "Settle"
 </pre>
 </div>
 <p>
@@ -29,7 +29,7 @@ for symbol in self.symbols:
     self.roc[symbol] = RateOfChange(period)
     hist = self.History([symbol], 400, Resolution.Daily).loc[symbol]
     for i in hist.itertuples():
-        self.roc[symbol].Update(i.Index, i.settle)
+        self.roc[symbol].Update(i.Index, i.value)
 </pre>
 </div>
 <p>

--- a/04 Strategy Library/27 Momentum Effect in Commodities Futures/03 Algorithm.html
+++ b/04 Strategy Library/27 Momentum Effect in Commodities Futures/03 Algorithm.html
@@ -1,6 +1,6 @@
 div class="qc-embed-frame" style="display: inline-block; position: relative; width: 100%; min-height: 100px; min-width: 300px;">
     <div class="qc-embed-dummy" style="padding-top: 56.25%;"></div>
     <div class="qc-embed-element" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;">
-        <iframe class="qc-embed-backtest" height="100%" width="100%" style="border: 1px solid #ccc; padding: 0; margin: 0;" src="https://www.quantconnect.com/terminal/index.php?key=processCache&request=embedded_backtest_203a6729604c80a71b5c3b2baa2b3f69.html"></iframe>
+        <iframe class="qc-embed-backtest" height="100%" width="100%" style="border: 1px solid #ccc; padding: 0; margin: 0;" src="https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_0414f4f614c36b28af3a0883bad4b018.html"></iframe>
     </div>
 </div>


### PR DESCRIPTION
1. In the CSV file from quandl, the column is called "Settle" instead of "settle".
2. When self.History call is made, the value column has been created, which is identical with settle column.