### PR TITLE
Update outdated introduction

### DIFF
--- a/03 Open Source/00 Introduction/Introduction.html
+++ b/03 Open Source/00 Introduction/Introduction.html
@@ -8,7 +8,7 @@ i.tutorial-link-icon { position: absolute; top: 15px; right: 15px }
 
 <a class="tutorial-link docs-internal-link" href="/tutorials/open-source/debugging-python">
   <div class="tutorial-box">    
-    <h4><i class="fa fa-list-alt"></i> Debugging Python</h4>
+    <h4><i class="fa fa-list-alt"></i> 100 Debugging Python</h4>
     <p>Explore different methods to debug python algorithms.</p>
     <i class="fa fa-external-link tutorial-link-icon"></i>
   </div>

--- a/03 Open Source/00 Introduction/Introduction.html
+++ b/03 Open Source/00 Introduction/Introduction.html
@@ -6,10 +6,10 @@ a.tutorial-link:hover  { text-decoration: none; }
 i.tutorial-link-icon { position: absolute; top: 15px; right: 15px } 
 </style>
 
-<a class="tutorial-link docs-internal-link" href="/tutorials/open-source/desktop-charting-with-lean">
+<a class="tutorial-link docs-internal-link" href="/tutorials/open-source/debugging-python">
   <div class="tutorial-box">    
-    <h4><i class="fa fa-list-alt"></i> 100 Desktop Charting with LEAN</h4>    
-    <p>Guide to using the desktop charting environment that comes with LEAN (UX v1.0).</p>
+    <h4><i class="fa fa-list-alt"></i> Debugging Python</h4>
+    <p>Explore different methods to debug python algorithms.</p>
     <i class="fa fa-external-link tutorial-link-icon"></i>
   </div>
 </a>
@@ -17,7 +17,7 @@ i.tutorial-link-icon { position: absolute; top: 15px; right: 15px }
 <a class="tutorial-link docs-internal-link" href="/tutorials/open-source/backtesting-from-visual-studio">
   <div class="tutorial-box">    
     <h4><i class="fa fa-windows"></i> 101 Backtesting from Visual Studio</h4>    
-    <p>VIsual Studio plugin integrated with the QuantConnect API.</p>
+    <p>Visual Studio plugin integrated with the QuantConnect API.</p>
     <i class="fa fa-external-link tutorial-link-icon"></i>
   </div>
 </a>


### PR DESCRIPTION
Desktop charting was removed in 
https://github.com/QuantConnect/Tutorials/commit/9b9b3bddba751b4bb42c4b3161143f82e8520b95

Replaced it with "Debugging python" section.
