### PR TITLE
Add new strategy mapping for search table

### DIFF
--- a/04 Strategy Library/00 Strategy Library/01 Strategy Library.php
+++ b/04 Strategy Library/00 Strategy Library/01 Strategy Library.php
@@ -513,6 +513,15 @@ $strategyMap = [
         'description' => "Invests in stocks with low P/E ratio.",
         'tags'=>'Beginner,Fundamental Factors,Equities'
     ],
+    [
+        'name' => 'Mean-Reversion Statistical Arbitrage Strategy in Stocks',
+        'link' => 'strategy-library/mean-reversion-statistical-arbitrage-strategy-in-stocks',
+        'sources' => [
+            'NYU' => 'https://www.math.nyu.edu/faculty/avellane/AvellanedaLeeStatArb071108.pdf'
+        ],
+        'description' => "Apply statistical arbitrage to take advantage of pricing inefficiencies in stocks.",
+        'tags'=>'PCA,Mean Reversion,Stocks,Arbitrage'
+    ],
 ];
 
 ?>


### PR DESCRIPTION
https://www.quantconnect.com/tutorials/strategy-library/mean-reversion-statistical-arbitrage-strategy-in-stocks

This strategy is not showing up on the searchable list as it lacked mapping for dynamic html generation.