### PR TITLE
added var ticket =

### DIFF
--- a/01 API Tutorials/03 Tracking and Managing Orders/01 Overview.html
+++ b/01 API Tutorials/03 Tracking and Managing Orders/01 Overview.html
@@ -16,27 +16,27 @@
 <tbody>
 <tr>
 <td width="25%">Market Order</td>
-<td><code>var ticket = MarketOrder("SPY", 100);</code></td>
+<td><code class="csharp">var ticket = MarketOrder("SPY", 100);</code><code class="python">self.ticket = self.MarketOrder("SPY", 100)</code></td>
 </tr>
 <tr>
 <td>Limit Order</td>
-<td><code>var ticket = LimitOrder("SPY", 100, 100.10m);</code></td>
+<td><code class="csharp">var ticket = LimitOrder("SPY", 100, 100.10m);</code><code class="python">self.ticket = self.LimitOrder("SPY", 100, 100.1)</code></td>
 </tr>
 <tr>
 <td>Stop Market Order</td>
-<td><code>var ticket = StopMarketOrder("SPY", 100, 100.10m);</code></td>
+<td><code class="csharp">var ticket = StopMarketOrder("SPY", 100, 100.10m);</code><code class="python">self.ticket = self.StopMarketOrder("SPY", 100, 100.1)</code></td>
 </tr>
 <tr>
 <td>Stop Limit Order</td>
-<td><code>var ticket = StopLimitOrder("SPY", 100, 100.12m, 99.5m);</code></td>
+<td><code class="csharp">var ticket = StopLimitOrder("SPY", 100, 100.12m, 99.5m);</code><code class="python">self.ticket = self.StopLimitOrder("SPY", 100, 100.12, 99.5)</code></td>
 </tr>
 <tr>
 <td>Market On Open Order</td>
-<td><code>var ticket = MarketOnOpen("SPY", 100);</code></td>
+<td><code class="csharp">var ticket = MarketOnOpen("SPY", 100);</code><code class="python">self.ticket = self.MarketOnOpen("SPY", 100)</code></td>
 </tr>
 <tr>
 <td>Market On Close Order</td>
-<td><code>var ticket = MarketOnClose("SPY", 100);</code></td>
+<td><code class="csharp">var ticket = MarketOnClose("SPY", 100);</code><code class="python">self.ticket = self.MarketOnClose("SPY", 100)</code></td>
 </tr>
 </tbody>
 </table>

--- a/01 API Tutorials/03 Tracking and Managing Orders/01 Overview.html
+++ b/01 API Tutorials/03 Tracking and Managing Orders/01 Overview.html
@@ -16,7 +16,7 @@
 <tbody>
 <tr>
 <td width="25%">Market Order</td>
-<td><code>MarketOrder("SPY", 100);</code></td>
+<td><code>var ticket = MarketOrder("SPY", 100);</code></td>
 </tr>
 <tr>
 <td>Limit Order</td>


### PR DESCRIPTION
The MarketOrder example stands out because it is missing 'var ticket ='. Fixed that.