### PR TITLE
removed reference to a C# example

### DIFF
--- a/01 API Tutorials/03 Tracking and Managing Orders/02 Updating Orders.html
+++ b/01 API Tutorials/03 Tracking and Managing Orders/02 Updating Orders.html
@@ -1,5 +1,5 @@
 <p>
-Once you have an order ticket you can use it to get order fields. In <b>C#</b> it looks like:
+Once you have an order ticket you can use it to get order fields.
 </p>
 <div class="section-example-container">
 <pre class="csharp">var currentStopPrice = _ticket.Get(OrderField.StopPrice);


### PR DESCRIPTION
The example includes both C# and Python code, yet the text refers to only C#.