### PR TITLE
Correction of a typo

### DIFF
--- a/05 Introduction to Financial Python[]/12 Modern Portfolio Theory/04 Mean-Variance Analysis.html
+++ b/05 Introduction to Financial Python[]/12 Modern Portfolio Theory/04 Mean-Variance Analysis.html
@@ -26,7 +26,7 @@
   Since there is only <em>n</em> = 1 risky asset, the variance of the CML portfolio return is
 </p>
 
-\[ \text{Var} (R_P) = w^2 \text{Var} (R_{\text{market}}}) \]
+\[ \text{Var} (R_P) = w^2 \text{Var} (R_{\text{market}}) \]
 
 <p>
   Taking square roots, we deduce that a CML portfolio's risk is proportional to the market portfolio's weight:


### PR DESCRIPTION
\text{Var} (R_P) = w^2 \text{Var} (R_{\text{market}}}) →\text{Var} (R_P) = w^2 \text{Var} (R_{\text{market}})
As per: https://github.com/QuantConnect/Tutorials/issues/319